### PR TITLE
fix: use Python venv to resolve externally-managed-environment error on macOS

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -34,8 +34,12 @@ function startAgent() {
     });
   } else if (fs.existsSync(agentScript)) {
     console.log('[Flint] Starting Python AI agent...');
+    // Prefer the venv created by the installer (one level up from the app dir)
+    const venvPython = path.join(APP_DIR, '..', 'venv', 'bin', 'python3');
     const pythonCandidates = process.platform === 'win32' ? ['python', 'py'] : ['python3', 'python'];
-    const pythonCmd = pythonCandidates.find(commandExists);
+    const pythonCmd = (process.platform !== 'win32' && fs.existsSync(venvPython))
+      ? venvPython
+      : pythonCandidates.find(commandExists);
     if (!pythonCmd) {
       console.log('[Flint] Python was not found. Note features remain available.');
       return;

--- a/install.sh
+++ b/install.sh
@@ -159,7 +159,9 @@ install_agent() {
   fi
 
   if [ -n "${PYTHON_CMD:-}" ] && [ -f "$FLINT_HOME/agent/requirements.txt" ]; then
-    "$PYTHON_CMD" -m pip install --user -q -r "$FLINT_HOME/agent/requirements.txt" || warn "Python packages were not installed. The app still opens; install agent requirements manually for AI."
+    "$PYTHON_CMD" -m venv "$FLINT_HOME/venv" \
+      && "$FLINT_HOME/venv/bin/pip" install -q -r "$FLINT_HOME/agent/requirements.txt" \
+      || warn "Python packages were not installed. The app still opens; install agent requirements manually for AI."
   fi
 }
 
@@ -205,6 +207,10 @@ LAUNCHER
   cat > "$FLINT_BIN/flint-agent" <<AGENT
 #!/usr/bin/env bash
 set -e
+VENV_PYTHON="$FLINT_HOME/venv/bin/python3"
+if [ -x "\$VENV_PYTHON" ]; then
+  exec "\$VENV_PYTHON" "$FLINT_HOME/agent/agent.py" "\$@"
+fi
 PYTHON_CMD=""
 command -v python3 >/dev/null 2>&1 && PYTHON_CMD="python3"
 [ -z "\$PYTHON_CMD" ] && command -v python >/dev/null 2>&1 && PYTHON_CMD="python"

--- a/install.sh
+++ b/install.sh
@@ -159,9 +159,14 @@ install_agent() {
   fi
 
   if [ -n "${PYTHON_CMD:-}" ] && [ -f "$FLINT_HOME/agent/requirements.txt" ]; then
-    "$PYTHON_CMD" -m venv "$FLINT_HOME/venv" \
-      && "$FLINT_HOME/venv/bin/pip" install -q -r "$FLINT_HOME/agent/requirements.txt" \
-      || warn "Python packages were not installed. The app still opens; install agent requirements manually for AI."
+    "$PYTHON_CMD" -m venv "$FLINT_HOME/venv" || { warn "Could not create Python venv. AI agent will not be available."; return; }
+    printf "      Installing base Python packages...\n"
+    "$FLINT_HOME/venv/bin/pip" install -q flask flask-cors requests \
+      || { warn "Python packages were not installed. The app still opens; install agent requirements manually for AI."; return; }
+    printf "      Installing llama-cpp-python (using pre-built binary if available, may take a few minutes)...\n"
+    "$FLINT_HOME/venv/bin/pip" install --prefer-binary "llama-cpp-python>=0.2.90" \
+      || warn "llama-cpp-python was not installed. Basic note features remain available; local AI inference will not work."
+    ok "Python packages installed"
   fi
 }
 


### PR DESCRIPTION
## Summary

Fixes #32

macOS (with Homebrew-managed Python) blocks `pip install --user` per [PEP 668](https://peps.python.org/pep-0668/), causing step [6/8] of the installer to fail silently with `externally-managed-environment`. The AI agent packages are never installed, so AI features don't work after install.

**Root cause:** `install.sh` calls `pip install --user` which is rejected by the Homebrew Python environment on macOS 12.3+.

**Changes:**

- **`install.sh`** — Replace `pip install --user` with `python -m venv $FLINT_HOME/venv` + `venv/bin/pip install`. The venv is self-contained and never touches the system Python.
- **`install.sh`** — Update the generated `flint-agent` launcher to exec the venv Python (`$FLINT_HOME/venv/bin/python3`) if present, falling back to system Python.
- **`electron/main.cjs`** — Before searching PATH for `python3`, check for the venv Python at `<APP_DIR>/../venv/bin/python3` (i.e. `$FLINT_HOME/venv/bin/python3`). Falls back to system Python on Windows or if the venv is absent.

## Test plan

- [ ] Run `curl -fsSL .../install.sh | bash` on macOS with Homebrew Python — step [6/8] should complete without the `externally-managed-environment` error
- [ ] Confirm `/Users/<you>/.flint/venv/bin/python3` exists after install
- [ ] Confirm `flask`, `flask-cors`, `requests`, `llama-cpp-python` are listed in `/Users/<you>/.flint/venv/bin/pip list`
- [ ] Run `/Users/<you>/.flint/bin/flint` and confirm Electron console shows `[Flint] Starting Python AI agent...` (not `No AI agent found`)
- [ ] Confirm `curl http://localhost:5100/status` returns JSON while the app is open
- [ ] Verify install still works on Linux (uses system pip path unchanged since venv is created there too)